### PR TITLE
Hytale

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ subprojects {
     apply plugin: 'org.cadixdev.licenser'
 
     ext {
-        baseVersion = '1.10.158'
+        baseVersion = '1.10.165'
         pluginVersion = baseVersion + '-SNAPSHOT'
         pluginDescription = 'spark is a performance profiling plugin/mod for Minecraft clients, servers and proxies.'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ rootProject.name = 'spark-extra-platforms'
 include (
         'spark-folia',
         'spark-geyser',
+        'spark-hytale',
         'spark-minestom',
         'spark-nukkit',
         'spark-sponge7',

--- a/spark-folia/src/main/java/me/lucko/spark/folia/FoliaTickStatistics.java
+++ b/spark-folia/src/main/java/me/lucko/spark/folia/FoliaTickStatistics.java
@@ -48,6 +48,11 @@ public class FoliaTickStatistics implements TickStatistics {
     }
 
     @Override
+    public int gameTargetTps() {
+        return 20;
+    }
+
+    @Override
     public double tps5Sec() {
         return tps(StatisticWindow.TicksPerSecond.SECONDS_5);
     }

--- a/spark-geyser/src/main/java/me/lucko/spark/geyser/GeyserSparkExtension.java
+++ b/spark-geyser/src/main/java/me/lucko/spark/geyser/GeyserSparkExtension.java
@@ -73,7 +73,7 @@ public class GeyserSparkExtension implements SparkPlugin, Extension {
 
     @Subscribe
     public void onCommandDefine(GeyserDefineCommandsEvent event) {
-        for (me.lucko.spark.common.command.Command command : this.platform.getCommands()) {
+        for (me.lucko.spark.common.command.Command command : this.platform.getCommandManager().getCommands()) {
             event.register(Command.builder(this)
                 .source(CommandSource.class)
                 .name(command.primaryAlias())

--- a/spark-hytale/build.gradle
+++ b/spark-hytale/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'com.gradleup.shadow' version '8.3.0'
+}
+
+tasks.withType(JavaCompile) {
+    options.release = 21
+}
+
+dependencies {
+    implementation "me.lucko:spark-common:${project.baseVersion}-SNAPSHOT"
+
+    implementation 'com.google.guava:guava:29.0-jre' // TODO: :(
+    implementation 'org.slf4j:slf4j-nop:1.7.36' // TODO: :(
+
+    compileOnly 'com.hypixel.hytale:Server:2026.01.24-6e2d4fc36'
+}
+
+repositories {
+    maven { url 'https://maven.hytale.com/release/' }
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        expand (
+                'pluginVersion': project.pluginVersion,
+                'pluginDescription': project.pluginDescription
+        )
+        include 'manifest.json'
+    }
+}
+
+shadowJar {
+    archiveFileName = "spark-${project.pluginVersion}-hytale.jar"
+
+    dependencies {
+        exclude(dependency('org.checkerframework:checker-qual'))
+        exclude(dependency('com.google.code.findbugs:jsr305'))
+    }
+
+    relocate 'net.kyori.adventure', 'me.lucko.spark.lib.adventure'
+    relocate 'net.kyori.examination', 'me.lucko.spark.lib.adventure.examination'
+    relocate 'net.kyori.option', 'me.lucko.spark.lib.adventure.option'
+    relocate 'net.bytebuddy', 'me.lucko.spark.lib.bytebuddy'
+    relocate 'com.google.protobuf', 'me.lucko.spark.lib.protobuf'
+    relocate 'org.objectweb.asm', 'me.lucko.spark.lib.asm'
+    relocate 'one.profiler', 'me.lucko.spark.lib.asyncprofiler'
+    relocate 'me.lucko.bytesocks.client', 'me.lucko.spark.lib.bytesocks'
+    relocate 'org.java_websocket', 'me.lucko.spark.lib.bytesocks.ws'
+
+    project.applyExcludes(delegate)
+}
+
+artifacts {
+    archives shadowJar
+    shadow shadowJar
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleClassSourceLookup.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleClassSourceLookup.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.hypixel.hytale.server.core.plugin.JavaPlugin;
+import com.hypixel.hytale.server.core.plugin.PluginClassLoader;
+import me.lucko.spark.common.sampler.source.ClassSourceLookup;
+
+import java.lang.reflect.Field;
+
+public class HytaleClassSourceLookup extends ClassSourceLookup.ByClassLoader {
+    private static final Field PLUGIN_FIELD;
+
+    static {
+        try {
+            PLUGIN_FIELD = PluginClassLoader.class.getDeclaredField("plugin");
+            PLUGIN_FIELD.setAccessible(true);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @Override
+    public String identify(ClassLoader loader) throws ReflectiveOperationException {
+        if (loader instanceof PluginClassLoader pluginClassLoader) {
+            JavaPlugin plugin = (JavaPlugin) PLUGIN_FIELD.get(pluginClassLoader);
+            return plugin.getName();
+        }
+        return null;
+    }
+
+}
+

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleCommandSender.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleCommandSender.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.hypixel.hytale.server.core.Message;
+import com.hypixel.hytale.server.core.command.system.CommandSender;
+import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.server.core.permissions.PermissionsModule;
+import com.hypixel.hytale.server.core.receiver.IMessageReceiver;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import me.lucko.spark.common.command.sender.AbstractCommandSender;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+import java.util.UUID;
+
+public abstract class HytaleCommandSender<T extends IMessageReceiver> extends AbstractCommandSender<T> {
+
+    public static HytaleCommandSender<?> of(CommandSender commandSender) {
+        return new CommandSenderWrapper(commandSender);
+    }
+
+    public static HytaleCommandSender<?> of(PlayerRef playerRef) {
+        return new PlayerRefWrapper(playerRef);
+    }
+
+    protected HytaleCommandSender(T delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected Object getObjectForComparison() {
+        UUID uniqueId = getUniqueId();
+        if (uniqueId != null) {
+            return uniqueId;
+        }
+        return getName();
+    }
+
+    @Override
+    public void sendMessage(Component component) {
+        this.delegate.sendMessage(toHytaleMessage(component));
+    }
+
+    private static Message toHytaleMessage(Component component) {
+        if (!(component instanceof TextComponent text)) {
+            throw new UnsupportedOperationException("Unsupported component type: " + component.getClass());
+        }
+
+        Message message = Message.raw(text.content());
+
+        TextColor color = text.color();
+        if (color != null) {
+            message.color(color.asHexString());
+        }
+
+        TextDecoration.State bold = text.decoration(TextDecoration.BOLD);
+        if (bold != TextDecoration.State.NOT_SET) {
+            message.bold(bold == TextDecoration.State.TRUE);
+        }
+
+        TextDecoration.State italic = text.decoration(TextDecoration.ITALIC);
+        if (italic != TextDecoration.State.NOT_SET) {
+            message.italic(italic == TextDecoration.State.TRUE);
+        }
+
+        ClickEvent clickEvent = text.clickEvent();
+        if (clickEvent != null && clickEvent.action() == ClickEvent.Action.OPEN_URL) {
+            message.link(clickEvent.value());
+        }
+
+        message.insertAll(text.children().stream()
+                .map(HytaleCommandSender::toHytaleMessage)
+                .toList()
+        );
+        return message;
+    }
+
+    private static final class CommandSenderWrapper extends HytaleCommandSender<CommandSender> {
+        public CommandSenderWrapper(CommandSender delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public String getName() {
+            return this.delegate.getDisplayName();
+        }
+
+        @Override
+        public UUID getUniqueId() {
+            if (this.delegate instanceof Player) {
+                return this.delegate.getUuid();
+            }
+            return null;
+        }
+
+        @Override
+        public boolean hasPermission(String permission) {
+            return this.delegate.hasPermission(permission);
+        }
+    }
+
+    private static final class PlayerRefWrapper extends HytaleCommandSender<PlayerRef> {
+        public PlayerRefWrapper(PlayerRef delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public String getName() {
+            return this.delegate.getUsername();
+        }
+
+        @Override
+        public UUID getUniqueId() {
+            return this.delegate.getUuid();
+        }
+
+        @Override
+        public boolean hasPermission(String permission) {
+            return PermissionsModule.get().hasPermission(this.delegate.getUuid(), permission);
+        }
+    }
+
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytalePlatformInfo.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytalePlatformInfo.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.hypixel.hytale.common.util.java.ManifestUtil;
+import me.lucko.spark.common.platform.PlatformInfo;
+
+public class HytalePlatformInfo implements PlatformInfo {
+
+    @Override
+    public Type getType() {
+        return Type.SERVER;
+    }
+
+    @Override
+    public String getName() {
+        return "Hytale";
+    }
+
+    @Override
+    public String getBrand() {
+        return "Hytale";
+    }
+
+    @Override
+    public String getVersion() {
+        return ManifestUtil.getImplementationVersion();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return null;
+    }
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytalePlayerPingProvider.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytalePlayerPingProvider.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.google.common.collect.ImmutableMap;
+import com.hypixel.hytale.protocol.packets.connection.PongType;
+import com.hypixel.hytale.server.core.io.PacketHandler;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.Universe;
+import me.lucko.spark.common.monitor.ping.PlayerPingProvider;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class HytalePlayerPingProvider implements PlayerPingProvider {
+
+    @Override
+    public Map<String, Integer> poll() {
+        ImmutableMap.Builder<String, Integer> builder = ImmutableMap.builder();
+        for (PlayerRef player : Universe.get().getPlayers()) {
+            PacketHandler.PingInfo pingInfo = player.getPacketHandler().getPingInfo(PongType.Tick);
+            long pingValue = pingInfo.getPingMetricSet().getLastValue();
+            int pingMillis = (int) TimeUnit.MILLISECONDS.convert(pingValue, PacketHandler.PingInfo.TIME_UNIT);
+            builder.put(player.getUsername(), pingMillis);
+        }
+        return builder.build();
+    }
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleServerConfigProvider.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleServerConfigProvider.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import me.lucko.spark.common.platform.serverconfig.ConfigParser;
+import me.lucko.spark.common.platform.serverconfig.ExcludedConfigFilter;
+import me.lucko.spark.common.platform.serverconfig.ServerConfigProvider;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Map;
+
+public class HytaleServerConfigProvider extends ServerConfigProvider {
+
+    /** A map of provided files and their type */
+    private static final Map<String, ConfigParser> FILES;
+    /** A collection of paths to be excluded from the files */
+    private static final Collection<String> HIDDEN_PATHS;
+
+    public HytaleServerConfigProvider() {
+        super(FILES, HIDDEN_PATHS);
+    }
+
+    static {
+        ImmutableSet.Builder<String> hiddenPaths = ImmutableSet.<String>builder()
+                .add("Password")
+                .addAll(getSystemPropertyList("spark.serverconfigs.hiddenpaths"));
+
+        FILES = ImmutableMap.of("config.json", JsonConfigParser.INSTANCE);
+        HIDDEN_PATHS = hiddenPaths.build();
+    }
+
+    private enum JsonConfigParser implements ConfigParser {
+        INSTANCE;
+
+        private static final Gson GSON = new Gson();
+
+        @Override
+        public JsonElement load(String file, ExcludedConfigFilter filter) throws IOException {
+            Path path = Paths.get(file);
+            if (!Files.exists(path)) {
+                return null;
+            }
+
+            try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+                JsonElement element = GSON.fromJson(reader, JsonElement.class);
+                if (element == null) {
+                    return null;
+                }
+                return filter.apply(element);
+            }
+        }
+
+        @Override
+        public Map<String, Object> parse(BufferedReader reader) {
+            // can more easily convert directly to JsonElement - only called internally
+            throw new UnsupportedOperationException();
+        }
+    }
+
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleSparkCommand.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleSparkCommand.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.hypixel.hytale.server.core.command.system.AbstractCommand;
+import com.hypixel.hytale.server.core.command.system.CommandContext;
+import com.hypixel.hytale.server.core.command.system.CommandSender;
+import com.hypixel.hytale.server.core.command.system.ParseResult;
+import com.hypixel.hytale.server.core.command.system.ParserContext;
+import me.lucko.spark.common.SparkPlatform;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+public class HytaleSparkCommand extends AbstractCommand {
+    private final SparkPlatform platform;
+
+    public HytaleSparkCommand(SparkPlatform platform) {
+        super("spark", "Spark command");
+        setAllowsExtraArguments(true);
+        requirePermission("spark");
+        this.platform = platform;
+    }
+
+    // we override acceptCall to handle parsing directly, spark arguments are not compatible with Hytale's command parser.
+    @Override
+    public @Nullable CompletableFuture<Void> acceptCall(@NonNull CommandSender sender, @NonNull ParserContext parserContext, @NonNull ParseResult parseResult) {
+        String inputString = parserContext.getInputString();
+        String[] args = inputString.split(" ");
+        return this.platform.executeCommand(HytaleCommandSender.of(sender), Arrays.copyOfRange(args, 1, args.length));
+    }
+
+    @Override
+    protected @Nullable CompletableFuture<Void> execute(@NonNull CommandContext ctx) {
+        // This method is never called because we override acceptCall above.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasPermission(@NonNull CommandSender sender) {
+        return this.platform.hasPermissionForAnyCommand(HytaleCommandSender.of(sender));
+    }
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleSparkPlugin.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleSparkPlugin.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.google.common.collect.ImmutableSet;
+import com.hypixel.hytale.common.plugin.AuthorInfo;
+import com.hypixel.hytale.server.core.command.system.CommandRegistration;
+import com.hypixel.hytale.server.core.console.ConsoleSender;
+import com.hypixel.hytale.server.core.plugin.JavaPlugin;
+import com.hypixel.hytale.server.core.plugin.JavaPluginInit;
+import com.hypixel.hytale.server.core.plugin.PluginBase;
+import com.hypixel.hytale.server.core.plugin.PluginManager;
+import com.hypixel.hytale.server.core.universe.Universe;
+import me.lucko.spark.common.SparkPlatform;
+import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.monitor.ping.PlayerPingProvider;
+import me.lucko.spark.common.monitor.tick.TickStatistics;
+import me.lucko.spark.common.platform.PlatformInfo;
+import me.lucko.spark.common.platform.serverconfig.ServerConfigProvider;
+import me.lucko.spark.common.platform.world.WorldInfoProvider;
+import me.lucko.spark.common.sampler.ThreadDumper;
+import me.lucko.spark.common.sampler.source.ClassSourceLookup;
+import me.lucko.spark.common.sampler.source.SourceMetadata;
+import me.lucko.spark.common.util.SparkThreadFactory;
+import org.jspecify.annotations.NonNull;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class HytaleSparkPlugin extends JavaPlugin implements SparkPlugin {
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(4, new SparkThreadFactory());
+    private final ThreadDumper gameThreadDumper = new ThreadDumper.Regex(ImmutableSet.of(
+            "WorldThread - .*",        // Main world threads (WorldThread - WorldName)
+            "WorldMap - .*",           // World map IO threads (WorldMap - WorldName)
+            "ChunkLighting - .*",      // Chunk lighting threads (ChunkLighting - WorldName)
+            "ChunkGenerator-.*",       // World generation workers (ChunkGenerator-N-Worker-M)
+            "ServerWorkerGroup.*",     // Netty IO worker threads (ServerWorkerGroup - N)
+            "ServerBossGroup.*",       // Netty IO boss threads (ServerBossGroup - N)
+            "Scheduler"                // Main scheduled executor
+    ));
+
+    private SparkPlatform platform;
+    private CommandRegistration command;
+
+    public HytaleSparkPlugin(@NonNull JavaPluginInit init) {
+        super(init);
+    }
+
+    @Override
+    protected void setup() {
+        this.platform = new SparkPlatform(this);
+        this.platform.enable();
+
+        this.command = getCommandRegistry().registerCommand(new HytaleSparkCommand(this.platform));
+    }
+
+    @Override
+    protected void shutdown() {
+        if (this.command != null) {
+            this.command.unregister();
+            this.command = null;
+        }
+
+        if (this.platform != null) {
+            this.platform.disable();
+            this.platform = null;
+        }
+
+        this.scheduler.shutdown();
+    }
+
+    @Override
+    public String getVersion() {
+        return getManifest().getVersion().toString();
+    }
+
+    @Override
+    public Path getPluginDirectory() {
+        return getDataDirectory();
+    }
+
+    @Override
+    public String getCommandName() {
+        return "spark";
+    }
+
+    @Override
+    public Stream<HytaleCommandSender<?>> getCommandSenders() {
+        return Stream.concat(
+                Universe.get().getPlayers().stream().map(HytaleCommandSender::of),
+                Stream.of(HytaleCommandSender.of(ConsoleSender.INSTANCE))
+        );
+    }
+
+    @Override
+    public void executeAsync(Runnable runnable) {
+        this.scheduler.execute(runnable);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new HytalePlatformInfo();
+    }
+
+    @Override
+    public ClassSourceLookup createClassSourceLookup() {
+        return new HytaleClassSourceLookup();
+    }
+
+    @Override
+    public Collection<SourceMetadata> getKnownSources() {
+        return SourceMetadata.gather(
+                PluginManager.get().getPlugins(),
+                PluginBase::getName,
+                plugin -> plugin.getManifest().getVersion().toString(),
+                plugin -> plugin.getManifest().getAuthors().stream().map(AuthorInfo::getName).collect(Collectors.joining(", ")),
+                plugin -> plugin.getManifest().getDescription(),
+                plugin -> plugin.getIdentifier().getGroup().equals("Hytale")
+        );
+    }
+
+    @Override
+    public ThreadDumper getDefaultThreadDumper() {
+        return this.gameThreadDumper;
+    }
+
+    @Override
+    public PlayerPingProvider createPlayerPingProvider() {
+        return new HytalePlayerPingProvider();
+    }
+
+    @Override
+    public ServerConfigProvider createServerConfigProvider() {
+        return new HytaleServerConfigProvider();
+    }
+
+    @Override
+    public TickStatistics createTickStatistics() {
+        return new HytaleTickStatistics();
+    }
+
+    @Override
+    public WorldInfoProvider createWorldInfoProvider() {
+        return new HytaleWorldInfoProvider(this);
+    }
+
+    @Override
+    public void log(Level level, String msg) {
+        getLogger().at(level).log(msg);
+    }
+
+    @Override
+    public void log(Level level, String msg, Throwable throwable) {
+        getLogger().at(level).withCause(throwable).log(msg);
+    }
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleTickStatistics.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleTickStatistics.java
@@ -1,0 +1,271 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.hypixel.hytale.metrics.metric.HistoricMetric;
+import com.hypixel.hytale.server.core.universe.Universe;
+import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.util.thread.TickingThread;
+import me.lucko.spark.api.statistic.misc.DoubleAverageInfo;
+import me.lucko.spark.common.monitor.tick.TickStatistics;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Provides tick statistics by reading from {@link World#getBufferedTickLengthMetricSet()}.
+ */
+public class HytaleTickStatistics implements TickStatistics {
+
+    @Override
+    public int gameTargetTps() {
+        return TickingThread.TPS;
+    }
+
+    @Override
+    public double tps5Sec() {
+        // close enough, easier to make use of the buffered tick length metric set periods
+        return tps10Sec();
+    }
+
+    @Override
+    public double tps10Sec() {
+        return calculateAverageTps(BufferedTickLengthMetricSetPeriod.SECONDS_10);
+    }
+
+    @Override
+    public double tps1Min() {
+        return calculateAverageTps(BufferedTickLengthMetricSetPeriod.MINUTES_1);
+    }
+
+    @Override
+    public double tps5Min() {
+        return calculateAverageTps(BufferedTickLengthMetricSetPeriod.MINUTES_5);
+    }
+
+    @Override
+    public double tps15Min() {
+        // hytale only stores 5 minutes of history, so that's the best we can do for now
+        return tps5Min();
+    }
+
+    @Override
+    public boolean isDurationSupported() {
+        return true;
+    }
+
+    @Override
+    public DoubleAverageInfo duration10Sec() {
+        return new AggregatedMsptInfo(getActiveWorlds(), BufferedTickLengthMetricSetPeriod.SECONDS_10);
+    }
+
+    @Override
+    public DoubleAverageInfo duration1Min() {
+        return new AggregatedMsptInfo(getActiveWorlds(), BufferedTickLengthMetricSetPeriod.MINUTES_1);
+    }
+
+    @Override
+    public DoubleAverageInfo duration5Min() {
+        return new AggregatedMsptInfo(getActiveWorlds(), BufferedTickLengthMetricSetPeriod.MINUTES_5);
+    }
+
+    private static List<World> getActiveWorlds() {
+        return Universe.get().getWorlds().values().stream()
+                .filter(world -> world.isStarted() && world.getBufferedTickLengthMetricSet() != null)
+                .collect(Collectors.toList());
+    }
+
+    private double calculateAverageTps(BufferedTickLengthMetricSetPeriod period) {
+        List<World> worlds = getActiveWorlds();
+        if (worlds.isEmpty()) {
+            return TickingThread.TPS;
+        }
+
+        BufferedTickLengthMetricSetPeriod.checkWorldMetricPeriodsMatch(worlds);
+
+        double totalTps = 0;
+        for (World world : worlds) {
+            totalTps += calculateWorldTps(world, period);
+        }
+
+        return totalTps / worlds.size();
+    }
+
+    private double calculateWorldTps(World world, BufferedTickLengthMetricSetPeriod period) {
+        HistoricMetric metrics = world.getBufferedTickLengthMetricSet();
+        double ticksProcessed = metrics.getTimestamps(period.ordinal()).length;
+        if (ticksProcessed == 0) {
+            return world.getTps();
+        }
+
+        return ticksProcessed / period.seconds();
+    }
+
+    private static class AggregatedMsptInfo implements DoubleAverageInfo {
+        private static final double NANOS_PER_MILLI = TimeUnit.MILLISECONDS.toNanos(1);
+
+        private final List<World> worlds;
+        private final BufferedTickLengthMetricSetPeriod period;
+
+        AggregatedMsptInfo(List<World> worlds, BufferedTickLengthMetricSetPeriod period) {
+            this.worlds = worlds;
+            this.period = period;
+            BufferedTickLengthMetricSetPeriod.checkWorldMetricPeriodsMatch(this.worlds);
+        }
+
+        @Override
+        public double mean() {
+            if (this.worlds.isEmpty()) {
+                return 0;
+            }
+
+            double total = 0;
+            int count = 0;
+
+            for (World world : this.worlds) {
+                HistoricMetric metric = world.getBufferedTickLengthMetricSet();
+                double avgNanos = metric.getAverage(this.period.ordinal());
+                if (avgNanos > 0) {
+                    total += avgNanos / NANOS_PER_MILLI;
+                    count++;
+                }
+            }
+
+            return count > 0 ? total / count : 0;
+        }
+
+        @Override
+        public double max() {
+            double max = 0;
+            for (World world : this.worlds) {
+                long maxNanos = world.getBufferedTickLengthMetricSet().calculateMax(this.period.ordinal());
+                if (maxNanos > 0 && maxNanos < Long.MAX_VALUE) {
+                    double ms = maxNanos / NANOS_PER_MILLI;
+                    if (ms > max) {
+                        max = ms;
+                    }
+                }
+            }
+            return max;
+        }
+
+        @Override
+        public double min() {
+            double min = Double.MAX_VALUE;
+            for (World world : this.worlds) {
+                long minNanos = world.getBufferedTickLengthMetricSet().calculateMin(this.period.ordinal());
+                if (minNanos > 0 && minNanos < Long.MAX_VALUE) {
+                    double ms = minNanos / NANOS_PER_MILLI;
+                    if (ms < min) {
+                        min = ms;
+                    }
+                }
+            }
+            return min == Double.MAX_VALUE ? 0 : min;
+        }
+
+        @Override
+        public double percentile(double percentile) {
+            if (percentile < 0 || percentile > 1) {
+                throw new IllegalArgumentException("Invalid percentile " + percentile);
+            }
+
+            long[] samples = new long[0];
+            for (World world : this.worlds) {
+                long[] values = world.getBufferedTickLengthMetricSet().getValues(this.period.ordinal());
+                samples = concat(samples, values);
+            }
+
+            if (samples.length == 0) {
+                return 0;
+            }
+
+            Arrays.sort(samples);
+
+            int rank = (int) Math.ceil(percentile * (samples.length - 1));
+            long sampleNanos = samples[rank];
+            return sampleNanos / NANOS_PER_MILLI;
+        }
+
+        public static long[] concat(long[] a1, long[] a2) {
+            if (a1 != null && a1.length != 0) {
+                if (a2 != null && a2.length != 0) {
+                    long[] newArray = Arrays.copyOf(a1, a1.length + a2.length);
+                    System.arraycopy(a2, 0, newArray, a1.length, a2.length);
+                    return newArray;
+                } else {
+                    return a1;
+                }
+            } else {
+                return a2;
+            }
+        }
+    }
+
+    /**
+     * The periods that are used by Hytale's {@link World#getBufferedTickLengthMetricSet()}
+     */
+    private enum BufferedTickLengthMetricSetPeriod {
+        SECONDS_10(10),
+        MINUTES_1(60),
+        MINUTES_5(60 * 5);
+
+        private static final AtomicBoolean CHECKED = new AtomicBoolean(false);
+
+        private final int seconds;
+        private final long nanos;
+
+        BufferedTickLengthMetricSetPeriod(int seconds) {
+            this.seconds = seconds;
+            this.nanos = TimeUnit.SECONDS.toNanos(seconds);
+        }
+
+        public int seconds() {
+            return this.seconds;
+        }
+
+        public long nanos() {
+            return this.nanos;
+        }
+
+        static void checkWorldMetricPeriodsMatch(List<World> worlds) {
+            if (CHECKED.get() || worlds.isEmpty()) {
+                return;
+            }
+
+            World world = worlds.getFirst();
+            HistoricMetric metric = world.getBufferedTickLengthMetricSet();
+
+            final long[] expectedPeriods = Arrays.stream(BufferedTickLengthMetricSetPeriod.values())
+                    .mapToLong(BufferedTickLengthMetricSetPeriod::nanos)
+                    .toArray();
+            final long[] actualPeriods = metric.getPeriodsNanos();
+
+            final boolean match = Arrays.equals(expectedPeriods, actualPeriods);
+            if (CHECKED.compareAndSet(false, true) && !match) {
+                System.err.println("[spark] warning: Hytale's BufferedTickLengthMetricSet periods do not match expected values.");
+            }
+        }
+    }
+}

--- a/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleWorldInfoProvider.java
+++ b/spark-hytale/src/main/java/me/lucko/spark/hytale/HytaleWorldInfoProvider.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.hytale;
+
+import com.hypixel.hytale.server.core.universe.Universe;
+import com.hypixel.hytale.server.core.universe.world.World;
+import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.platform.world.ChunkInfo;
+import me.lucko.spark.common.platform.world.WorldInfoProvider;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+
+public class HytaleWorldInfoProvider implements WorldInfoProvider {
+    private static final long TIMEOUT_SECONDS = 5;
+
+    private final SparkPlugin plugin;
+
+    public HytaleWorldInfoProvider(SparkPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public CountsResult pollCounts() {
+        Universe universe = Universe.get();
+
+        List<CompletableFuture<CountsResult>> futures = new ArrayList<>(universe.getWorlds().size());
+        for (World world : universe.getWorlds().values()) {
+            if (!world.isStarted()) {
+                continue;
+            }
+
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                int entities = world.getEntityStore().getStore().getEntityCount();
+                int chunks = world.getChunkStore().getLoadedChunksCount();
+                return new CountsResult(0, entities, 0, chunks);
+            }, world));
+        }
+
+        int players = universe.getPlayerCount();
+        int entities = 0;
+        int chunks = 0;
+
+        // Wait for all worlds and aggregate results
+        for (CompletableFuture<CountsResult> future : futures) {
+            CountsResult counts = getWithTimeout(future);
+            if (counts == null) {
+                continue;
+            }
+
+            entities += counts.entities();
+            chunks += counts.chunks();
+        }
+
+        return new CountsResult(players, entities, -1, chunks);
+    }
+
+    @Override
+    public ChunksResult<? extends ChunkInfo<?>> pollChunks() {
+        return null; // TODO
+    }
+
+    @Override
+    public GameRulesResult pollGameRules() {
+        // No equivalent in Hytale
+        return null;
+    }
+
+    @Override
+    public Collection<DataPackInfo> pollDataPacks() {
+        // No equivalent in Hytale
+        return null;
+    }
+
+    @Override
+    public boolean mustCallSync() {
+        // Hytale's world operations must be called on their respective world threads
+        return false;
+    }
+
+    private <T> T getWithTimeout(CompletableFuture<T> future) {
+        try {
+            return future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            this.plugin.log(Level.WARNING, "Timed out waiting for world statistics");
+            return null;
+        }
+    }
+
+
+}

--- a/spark-hytale/src/main/resources/manifest.json
+++ b/spark-hytale/src/main/resources/manifest.json
@@ -1,0 +1,14 @@
+{
+  "Group": "spark",
+  "Name": "spark",
+  "Version": "${pluginVersion}",
+  "Description": "spark is a performance profiling mod for Hytale",
+  "Authors": [{"Name": "Luck"}],
+  "Website": "https://spark.lucko.me/",
+  "ServerVersion": "*",
+  "Dependencies": {},
+  "OptionalDependencies": {},
+  "DisabledByDefault": false,
+  "Main": "me.lucko.spark.hytale.HytaleSparkPlugin",
+  "IncludesAssetPack": false
+}


### PR DESCRIPTION
> [!CAUTION]
> This is a very early preview and should be considered highly experimental.

An early build of spark for Hytale 🎉  (on release day! I had no early access)

I have cut quite a few corners and it will need to be refined, but it's usable enough! :)

**DOWNLOAD**: https://www.curseforge.com/hytale/mods/spark

Things that are missing:
* ~player ping stats - not yet added~ ✅ 
* ~server config data - not yet added~ ✅
* ~class sources (attribute classes/methods to mods) - not yet added~ ✅ 
* ~tick (TPS/MSPT) stats~ ✅ 
* world/entity stats - the viewer operates only in terms of Minecraft entities, so this will need some changes
* player info - spark viewer will currently assume that all players are Minecraft players, will pull back the Minecraft skin that corresponds to the Hytale username

Currently I have tested that it enables, the commands roughly work, and you can create/open a profiler:

<img width="1972" height="1057" alt="Screenshot 2026-01-13 at 19 37 23" src="https://github.com/user-attachments/assets/06579819-4a9c-4e4d-ab29-fed9c544e207" />

Have fun!