### PR TITLE
Bundle and relocate Guava in spark-waterdog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ subprojects {
     apply plugin: 'dev.yumi.gradle.licenser'
 
     ext {
-        baseVersion = '1.10.172'
+        baseVersion = '1.10.173'
         pluginVersion = baseVersion + '-SNAPSHOT'
         pluginDescription = 'spark is a performance profiling plugin/mod for Minecraft clients, servers and proxies.'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ subprojects {
     apply plugin: 'dev.yumi.gradle.licenser'
 
     ext {
-        baseVersion = '1.10.173'
+        baseVersion = '1.10.172'
         pluginVersion = baseVersion + '-SNAPSHOT'
         pluginDescription = 'spark is a performance profiling plugin/mod for Minecraft clients, servers and proxies.'
 

--- a/spark-waterdog/build.gradle
+++ b/spark-waterdog/build.gradle
@@ -9,6 +9,7 @@ tasks.withType(JavaCompile).configureEach {
 
 dependencies {
     implementation "me.lucko:spark-common:${project.baseVersion}-SNAPSHOT"
+    implementation 'com.google.guava:guava:19.0'
     compileOnly('dev.waterdog.waterdogpe:waterdog:1.2.3') {
         exclude group: 'com.nukkitx.protocol'
     }
@@ -33,6 +34,14 @@ processResources {
 shadowJar {
     archiveFileName = "spark-${project.pluginVersion}-waterdog.jar"
 
+    dependencies {
+        exclude(dependency('org.checkerframework:checker-qual'))
+        exclude(dependency('com.google.code.findbugs:jsr305'))
+    }
+
+    relocate('com.google.common', 'me.lucko.spark.lib.guava') {
+        exclude 'com.google.common.flogger.**'
+    }
     relocate 'net.kyori.adventure', 'me.lucko.spark.lib.adventure'
     relocate 'net.kyori.examination', 'me.lucko.spark.lib.adventure.examination'
     relocate 'net.kyori.option', 'me.lucko.spark.lib.adventure.option'

--- a/spark-waterdog/build.gradle
+++ b/spark-waterdog/build.gradle
@@ -39,9 +39,7 @@ shadowJar {
         exclude(dependency('com.google.code.findbugs:jsr305'))
     }
 
-    relocate('com.google.common', 'me.lucko.spark.lib.guava') {
-        exclude 'com.google.common.flogger.**'
-    }
+    relocate 'com.google.common', 'me.lucko.spark.lib.guava'
     relocate 'net.kyori.adventure', 'me.lucko.spark.lib.adventure'
     relocate 'net.kyori.examination', 'me.lucko.spark.lib.adventure.examination'
     relocate 'net.kyori.option', 'me.lucko.spark.lib.adventure.option'


### PR DESCRIPTION
WaterdogPE does not provide Guava on the plugin classloader, so spark failed on enable with NoClassDefFoundError for com.google.common.collect.ImmutableMap.

Bundle Guava and relocate it under me.lucko.spark.lib.guava, mirroring the spark-hytale and spark-minestom modules. Bump version to 1.10.173.